### PR TITLE
Escape the underline in the markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,5 +167,5 @@ dataset/
 |  
 |--- class_n/
 ```
-Each class name should be one word in the english language, or multiple words separated by "_". 
-In our example dataset for example, we rename the "diningtable" folder to dining'_'table.
+Each class name should be one word in the english language, or multiple words separated by "\_". 
+In our example dataset for example, we rename the "diningtable" folder to dining'\_'table.


### PR DESCRIPTION
The current file just emphasizes the parts inbetween the underlines (_). I escaped them to not do any formatting.